### PR TITLE
Refactor create

### DIFF
--- a/service/service.py
+++ b/service/service.py
@@ -57,8 +57,7 @@ api = Api(app,
 
 # query string arguments
 promotion_args = reqparse.RequestParser()
-promotion_args.add_argument('promotion-code', type=str, required=False, help='List Promotions by code')
-
+promotion_args.add_argument('promotion-code', type=str, required=False, help='List Promotions by code', location='args')
 #####################################################################
 # PATH: /promotions
 #####################################################################

--- a/service/service.py
+++ b/service/service.py
@@ -281,15 +281,6 @@ def mediatype_not_supported(error):
                    error='Unsupported media type',
                    message=message), status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
 
-@app.errorhandler(status.HTTP_500_INTERNAL_SERVER_ERROR)
-def internal_server_error(error):
-    """ Handles unexpected server error with 500_SERVER_ERROR """
-    message = str(error)
-    app.logger.error(message)
-    return jsonify(status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                   error='Internal Server Error',
-                   message=message), status.HTTP_500_INTERNAL_SERVER_ERROR
-
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################

--- a/service/service.py
+++ b/service/service.py
@@ -23,7 +23,6 @@ All service functions should be defined here
 
 import logging
 import sys
-from functools import wraps
 
 from flask import abort, jsonify, make_response, request, url_for
 from werkzeug.exceptions import NotFound

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -293,3 +293,8 @@ class TestPromotionServer(unittest.TestCase):
     def test_promotion_reset(self):
         resp = self.app.delete('/promotions/reset')
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_get_index(self):
+        resp = self.app.get('/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertTrue('text/html' in resp.headers['Content-Type'])


### PR DESCRIPTION
- Refactor `create` Promotion API
- To improve coverage
  - Remove `500` error handler as it is unreachable by running unit tests(I guess it is because the Flask RestPlus takes over the handle of it)
  - Add one new test case for `get index`
- Authorizations: If we require authorization for this `create` API, then our UI won't work for creation as we didn't pass an authorization header when calling `create` via our UI
- Modify the `List` API a little bit