### PR TITLE
Reject conflicted promotion

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -23,6 +23,7 @@ All models should be defined here
 
 import os
 import sys
+import time
 import json
 import logging
 from cloudant.client import Cloudant
@@ -79,6 +80,8 @@ class Promotion():
 
     def update(self):
         """ Updates a Promotion in the database """
+        self.validate()
+
         if self.id:
             try:
                 document = self.database[self.id]
@@ -90,8 +93,6 @@ class Promotion():
 
     def save(self):
         """ Saves a Promotion in the database """
-        self.validate()
-
         if self.id:
             self.update()
         else:
@@ -119,9 +120,23 @@ class Promotion():
             raise DataValidationError('expiry_date attribute is not set')
         if self.start_date is None:
             raise DataValidationError('start_date attribute is not set')
+        if self.start_date > self.expiry_date:
+            raise DataValidationError('start date should not be larger than expiry date')
         if self.percentage < 0 or self.percentage > 100:
             raise DataValidationError(
                 'Percentage should be in the range of 0 to 100')
+
+        # Check if this promotion conflicts with any existing promotions
+        promotions = Promotion.find_by_code(self.code)
+        for promotion in promotions:
+            print(f'in val {self.id}')
+            print(f'in val {promotion.id}')
+            if self.id is not None and self.id == promotion.id:
+                continue
+
+            if (promotion.start_date <= self.start_date and self.start_date <= promotion.expiry_date) or \
+                (promotion.start_date <= self.expiry_date and self.expiry_date <= promotion.expiry_date):
+                raise DataValidationError(f'This new/updated promotion conflicts with promotion({promotion.id})')
 
     def serialize(self):
         """ Serializes a Promotion into a dictionary """
@@ -159,6 +174,13 @@ class Promotion():
             self.id = data['_id']
 
         return self
+    
+    def is_active(self):
+        """
+        A promotion is active if the current timestamp is in its range [start_date, expiry_date]
+        """
+        now_ts = time.time()
+        return self.start_date <= now_ts and now_ts <= self.expiry_date
 
 ######################################################################
 #  S T A T I C   D A T A B S E   M E T H O D S

--- a/service/service.py
+++ b/service/service.py
@@ -217,6 +217,10 @@ class ApplyResource(Resource):
         if not promotion:
             api.abort(status.HTTP_404_NOT_FOUND, 'Promotion with id "{}" was not found.'.format(promotion_id))
 
+        # Check promotion availability
+        if not promotion.is_active():
+            api.abort(status.HTTP_409_CONFLICT, 'Promotion with id "{}" is not active.'.format(promotion_id))
+
         # Get product data
         try:
             products = data['products']

--- a/tests/promotion_factory.py
+++ b/tests/promotion_factory.py
@@ -7,7 +7,7 @@ import random
 from collections import defaultdict
 
 import factory
-from factory.fuzzy import FuzzyChoice, FuzzyDate
+from factory.fuzzy import FuzzyChoice
 from service.models import Promotion
 
 

--- a/tests/promotion_factory.py
+++ b/tests/promotion_factory.py
@@ -40,7 +40,7 @@ class PromotionFactory(factory.Factory):
             promos[0].save()
             for promotion in promos[1:]:
                 delta = promotion.expiry_date-promotion.start_date
-                promotion.start_date = pre_expiry_date+1
+                promotion.start_date = pre_expiry_date+random.randint(100, 2000)
                 promotion.expiry_date = promotion.start_date+delta
                 pre_expiry_date = promotion.expiry_date
                 promotion.save()

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -35,10 +35,7 @@ class TestPromotion(unittest.TestCase):
         codes = ['SAVE15', 'SAVE20', 'SAVE30']
         counts = [10, 15, 2]
         for count, code in zip(counts, codes):
-            for _ in range(count):
-                promotion = PromotionFactory()
-                promotion.code = code
-                promotion.save()
+            PromotionFactory.batch_create(count, code=code)
 
         for count, code in zip(counts, codes):
             promotions = Promotion.find_by_code(code)
@@ -48,16 +45,8 @@ class TestPromotion(unittest.TestCase):
 
     def test_find(self):
         """ Find a Promotion by ID """
-        Promotion(code='SAVE30',
-                  percentage=70,
-                  products=[],
-                  start_date='2019-10-01',
-                  expiry_date='2019-11-01').save()
-        save50 = Promotion(code="SAVE50",
-                           percentage=50,
-                           products=[],
-                           start_date=43155131,
-                           expiry_date=5361332)
+        PromotionFactory(code="SAVE30").save()
+        save50 = PromotionFactory(code="SAVE50")
         save50.save()
 
         promotion = Promotion.find(save50.id)
@@ -68,15 +57,22 @@ class TestPromotion(unittest.TestCase):
 
     def test_add_a_promotion(self):
         """ Create a promotion """
-        promotion = Promotion(code="SAVE50",
-                              percentage=50,
-                              products=[],
-                              start_date=43155131,
-                              expiry_date=5361332)
+        promotion = PromotionFactory(code="SAVE50")
         promotion.save()
         promotions = Promotion.all()
         self.assertEqual(len(promotions), 1)
         self.assertEqual(promotions[0].code, "SAVE50")
+    
+    def test_update_promotion(self):
+        """ Update a promotion """
+        promotion = PromotionFactory()
+        promotion.save()
+        self.assertEqual(len(Promotion.find_by_code(promotion.code)), 1)
+        promotion.percentage = 80
+        promotion.start_date = promotion.start_date+1000
+        promotion.expiry_date = promotion.expiry_date+1000
+        promotion.save()
+        self.assertEqual(len(Promotion.find_by_code(promotion.code)), 1)
 
     def test_promotion_deserialize(self):
         """ Test Promotion deserialization"""

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -115,9 +115,7 @@ class TestPromotionServer(unittest.TestCase):
 
         # start date > expiry date
         promotion = PromotionFactory()
-        ts = promotion.start_date
-        promotion.start_date = promotion.expiry_date
-        promotion.expiry_date = ts
+        promotion.start_date, promotion.expiry_date = promotion.expiry_date, promotion.start_date
         resp = self.app.post('/promotions', data=json.dumps(dict(
             code=promotion.code,
             percentage=promotion.percentage,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -6,6 +6,7 @@ Test cases can be run with the following:
   codecov --token=$CODECOV_TOKEN
 """
 
+import time
 import unittest
 import json
 import logging
@@ -38,8 +39,7 @@ class TestPromotionServer(unittest.TestCase):
     def test_list_all_promotions(self):
         """ Get a list of all Promotions in DB """
         count = 5
-        for _ in range(count):
-            PromotionFactory().save()
+        PromotionFactory.batch_create(count)
         resp = self.app.get('/promotions')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
@@ -47,14 +47,11 @@ class TestPromotionServer(unittest.TestCase):
 
     def test_get_promotions_by_code(self):
         """ Get a list of all Promotions having a given code """
-        PromotionFactory.batch_create(10)
+        PromotionFactory.batch_create(10, code='SAVE15')
         count = 5
         code = 'SAVE_NOTHING'
-        for _ in range(count):
-            promotion = PromotionFactory()
-            promotion.code = code
-            promotion.save()
-        PromotionFactory.batch_create(12)
+        PromotionFactory.batch_create(count, code=code)
+        PromotionFactory.batch_create(12, code='SAVE20')
         resp = self.app.get('/promotions?promotion-code={}'.format(code))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
@@ -112,6 +109,47 @@ class TestPromotionServer(unittest.TestCase):
         self.assertEqual(new_prom['start_date'],
                          promotion.start_date, "Start date does not match")
         self.assertTrue(set(promotion.products) == set(new_prom['products']))
+    
+    def test_create_a_promotion_with_bad_data(self):
+        """ Create a promotion with bad data"""
+
+        # start date > expiry date
+        promotion = PromotionFactory()
+        ts = promotion.start_date
+        promotion.start_date = promotion.expiry_date
+        promotion.expiry_date = ts
+        resp = self.app.post('/promotions', data=json.dumps(dict(
+            code=promotion.code,
+            percentage=promotion.percentage,
+            expiry_date=promotion.expiry_date,
+            start_date=promotion.start_date,
+            products=promotion.products
+        )), content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # conflict with others
+        promotion1 = PromotionFactory()
+        resp = self.app.post('/promotions', data=json.dumps(dict(
+            code=promotion1.code,
+            percentage=promotion1.percentage,
+            expiry_date=promotion1.expiry_date,
+            start_date=promotion1.start_date,
+            products=promotion1.products
+        )), content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        promotion2 = PromotionFactory()
+        promotion2.code = promotion1.code
+        promotion2.start_date = (promotion1.start_date+promotion1.expiry_date)//2
+        promotion2.expiry_date = promotion2.start_date+1000
+        resp = self.app.post('/promotions', data=json.dumps(dict(
+            code=promotion2.code,
+            percentage=promotion2.percentage,
+            expiry_date=promotion2.expiry_date,
+            start_date=promotion2.start_date,
+            products=promotion2.products
+        )), content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_apply_a_promotion_on_products(self):
         """ Apply a promotion on a set of products together with their prices """
@@ -147,6 +185,28 @@ class TestPromotionServer(unittest.TestCase):
         resp_data = resp.get_json()
         for product in resp_data['products']:
             self.assertEqual(product['price'], ground_truth[product['product_id']])
+    
+    def test_apply_a_inactive_promotion_on_products(self):
+        """ Apply a inactive promotion on a set of products together with their prices """
+        # Set up fake data
+        product_ids = ['ae12GH1vfg2KC51a', 'c2GH374g2C51dacg', 'c3573HEYv02351dh']
+        prices = [200, 352.12, 101.99]
+        products = product_ids[:-1]
+        test_promotion = PromotionFactory()
+        test_promotion.products = products
+        test_promotion.start_date = time.time()+1000
+        test_promotion.expiry_date = test_promotion.start_date+1000
+        test_promotion.save()
+
+        # Create request json data
+        request_data = {'products': []}
+        for product_id, price in zip(product_ids, prices):
+            request_data['products'].append({'product_id': product_id, 'price': price})
+        
+        resp = self.app.post('/promotions/{}/apply'.format(test_promotion.id),
+                             json=request_data,
+                             content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_409_CONFLICT)
 
     def test_update_a_promotion(self):
         """ Update a promotion, given a promotion id """
@@ -160,6 +220,8 @@ class TestPromotionServer(unittest.TestCase):
         #update a promotion
         new_promotion = resp.get_json()
         new_promotion['code'] = 'SAVENEW'
+        new_promotion['start_date'] = test_promotion.start_date+100
+        new_promotion['expiry_date'] = test_promotion.expiry_date+100
         resp = self.app.put('/promotions/{}'.format(new_promotion['id']),
                             json=new_promotion,
                             content_type='application/json')


### PR DESCRIPTION
- Reject conflicted promotion in `Update` and `Create`
  - Conflict means that two promotions have the same code and their active periods have overlaps
  - Abort with 400
- Check active status in `Apply`
- Add more tests